### PR TITLE
Remove !important from userstyles.php 

### DIFF
--- a/userstyles.php
+++ b/userstyles.php
@@ -61,7 +61,7 @@ if (!empty($fontsize) || !empty($colourscheme)) {
     // Echo out CSS for the body element. Use !important to override any other external
     // stylesheets.
     if (!empty($fontsize)) {
-        echo '#page {font-size: '.$fontsize.'% !important;}';
+        echo '#page {font-size: '.$fontsize.'%;}';
     }
     if (!empty($colourscheme)) {
         switch ($colourscheme) {


### PR DESCRIPTION
Hi Mark,

In testing this block we found that if the user had previously saved font size settings, then the `!important` on the setting loaded in userstyles.php prevented any visible change when the font size buttons were clicked. 

The CSS from userstyles.php, for example: 

```
#page { font-size: 93% !important; }
```

Even though the local style is written by JS to the `#page` element, it can't override that `!important`:

```
<div id="page" style="font-size: 85%;">
```

It looks like a previous commit removed the `!important`s from module.js. Perhaps they should be removed from userstyles.php as well? 

Regards,
Amy
