### PR TITLE
bug fixes for issues 36,37,38

### DIFF
--- a/block_accessibility.php
+++ b/block_accessibility.php
@@ -45,11 +45,6 @@ class block_accessibility extends block_base {
     public function init() {
         global $PAGE;
         $this->title = get_string('pluginname', 'block_accessibility');
-        
-        if (!$PAGE->requires->is_head_done()){
-            $cssurl = '/blocks/accessibility/userstyles.php';
-            $PAGE->requires->css($cssurl);
-        }
     }
 
     /**

--- a/userstyles.php
+++ b/userstyles.php
@@ -36,56 +36,22 @@ if (!isloggedin()) {
     die();
 }
 
-header('Content-Type: text/css');
+header('Content-Type: text/plain');
 // First, check the session to see if the user's overridden the default/saved setting
 $options = $DB->get_record('block_accessibility', array('userid' => $USER->id));
 
 if (!empty($USER->fontsize)) {
-
-    $fontsize = $USER->fontsize;
-
+    echo $USER->fontsize;
 } else if (!empty($options->fontsize)) {
-    $fontsize = $options->fontsize;
+    echo $options->fontsize;
+} else {
+    echo -1;
 }
+echo ",";
 if (!empty($USER->colourscheme)) {
-
-    $colourscheme = $USER->colourscheme;
-
+    echo $USER->colourscheme;
 } else if (!empty($options->colourscheme)) {
-
-     $colourscheme = $options->colourscheme;
-
-}
-
-if (!empty($fontsize) || !empty($colourscheme)) {
-    // Echo out CSS for the body element. Use !important to override any other external
-    // stylesheets.
-    if (!empty($fontsize)) {
-        echo '#page {font-size: '.$fontsize.'% !important;}';
-    }
-    if (!empty($colourscheme)) {
-        switch ($colourscheme) {
-            case 2:
-                echo '* {background-color: #ffc !important;};
-                    forumpost .topic {background-image: none !important;}
-                    * {background-image: none !important;}';
-                break;
-
-            case 3:
-                echo '* {background-color: #9cf !important;}
-                    forumpost .topic {background-image: none !important;}
-                    * {background-image: none !important;}';
-                break;
-
-            case 4:
-                echo '* {color: #ffff00 !important;}
-                    * {background-color: #000 !important;}
-                    * {background-image: none !important;}
-                    #content a, .tabrow0 span {color: #ff0 !important;}
-                    .tabrow0 span:hover {text-decoration: underline;}
-                    .block_accessibility .outer {border-color:#fff !important;}';
-                break;
-
-        }
-    }
+    echo $options->colourscheme;
+} else {
+    echo -1;
 }


### PR DESCRIPTION
The userstyles.php file has been rewritten to output a CVS file with information on the font size and color scheme chosen. The javascript reads this file and uses the values to enable the proper settings. Prior to this change, styles were being written with an echo statement. This approach conflicted with the stylesheets created in module.js. I removed the requires->css call in block_accessibility.php because it is no longer needed (since userstyles.php no longer is a css file).

In module.js I created arrays to hold styles (a string of CSS) and stylesheets (a JavaScript stylesheet). I rewrote the javascript that handles the changing of color schemes to utilize the array structure. I made this change so in the future more color schemes can be added with minimal changes to the code (change the variable numberOfColours and push a style on the styles array is all you need to do). I edited the stylesheets to exclude css styles for TinyMCE editor so the icons appear in the TinyMCE editor. The exclusion will only work in browsers that support the :not() selector in CSS
