### PR TITLE
$PAGE replaced with $this->page

### DIFF
--- a/block_accessibility.php
+++ b/block_accessibility.php
@@ -59,16 +59,15 @@ class block_accessibility extends block_base {
 	 *
 	 */
 	public function specialization(){
-		global $PAGE;
 		$instance_id = $this->instance->id;
 
 		
-		if (!$PAGE->requires->is_head_done()){
+		if (!$this->page->requires->is_head_done()){
 
 			// link default/saved settings to a page
 			// each block instance has it's own configuration form, so we need instance id
 			$cssurl = CSS_URL.'?instance_id='.$instance_id;
-			$PAGE->requires->css($cssurl);
+			$this->page->requires->css($cssurl);
 		}
 	}
 


### PR DESCRIPTION
As of Moodle 2.0, very block now has access to the page it appears on, via $this->page. (Therefore, you do not have to use the global $PAGE object in blocks!) http://docs.moodle.org/dev/Blocks/Appendix_A
