### PR TITLE
TinyMCE editor color profile fix

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -55,6 +55,7 @@ define('DEFAULT_AUTOSAVE', FALSE);
 function accessibility_getsize($size) {
 
     // Define the array of sizes in px against sizes as %
+    // make sure to maintain defined constants above in the script
     $sizes = array(
         10 => 77,
         11 => 85,

--- a/userstyles.php
+++ b/userstyles.php
@@ -105,7 +105,8 @@ if (!empty($colourscheme)) {
 		forumpost .topic {
 			background-image: none !important;
 		}
-		*{
+		*:not([class*="mce"]):not([id*="mce"]):not([id*="editor"]){
+			/* it works well only with * selector but mce editor gets unusable */
 			background-color: '.$bg_colour.' !important;
 			background-image: none !important;
 			text-shadow:none !important;
@@ -115,7 +116,8 @@ if (!empty($colourscheme)) {
 
 	// it is recommended not to change forground colour
 	if(!empty($fg_colour)){ echo '
-		*{
+		*:not([class*="mce"]):not([id*="mce"]):not([id*="editor"]){
+			/* it works well only with * selector but mce editor gets unusable */
 			color: '.$fg_colour.' !important;
 		}
 		#content a, .tabrow0 span {

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2014042803;
+$plugin->version = 2014050501;
 $plugin->cron = 3600;
 $plugin->requires = 2011120500;
 $plugin->component = 'block_accessibility';


### PR DESCRIPTION
editor looked like this before:
![err3](https://cloud.githubusercontent.com/assets/6906827/3004708/8c719c52-ddb4-11e3-88ab-419b5576a343.PNG)

after fix:
![pro1](https://cloud.githubusercontent.com/assets/6906827/3004709/943f0564-ddb4-11e3-9f65-5ad546886423.PNG)

However, the issue #38 remains open because it doesn't solve it completely. However, the solution is satisfactory and it's so far the best that can be done due to :not selector limitations:
http://stackoverflow.com/questions/23698584/how-to-select-all-elements-except-specific-one-and-all-its-descendants
For the same reason, this will not work in IE older than 9

Thanks @zherman for the code. This closes #39
