### PR TITLE
Initial plugin style improved

### DIFF
--- a/block_accessibility.php
+++ b/block_accessibility.php
@@ -233,7 +233,6 @@ class block_accessibility extends block_base {
 
 		$content .= html_writer::end_tag('ul');
 
-		$content .= html_writer::end_tag('div');
 
 		// e.g. "settings saved" or etc.
 		if (isset($USER->accessabilitymsg)) {
@@ -285,15 +284,22 @@ class block_accessibility extends block_base {
 				'type' => 'button',
 				'value' => get_string('launchtoolbar', 'block_accessibility'),
 				'id' => 'block_accessibility_launchtoolbar',
-				'class' => 'atbar_control'
+				'class' => 'atbar_control access-button'
 			);
 
 			// render ATBar
 			$content .= html_writer::empty_tag('input', $launch_attrs);
+
+			$spanattrs = array('class' => 'atbar-always');
+			$content .= html_writer::start_tag('span', $spanattrs);
 			$content .= html_writer::empty_tag('input', $checkbox_attrs);
 			$strlaunch = get_string('autolaunch', 'block_accessibility');
 			$content .= html_writer::tag('label', $strlaunch, $label_attrs);
+			$content .= html_writer::end_tag('span');
 		}
+
+		$content .= html_writer::end_tag('div');
+
 
 		// SET THE BLOCK CONTENT
 		// ===============================================

--- a/styles.css
+++ b/styles.css
@@ -5,12 +5,9 @@ body.jsdisabled #block_accessibility_launchtoolbar {
 #accessibility_controls .access-button {
     display: inline-block;
     vertical-align: middle;
-    margin: 0 .2em;
+    margin: 0 .15em;
     border: 1px solid #ccc;
     border-radius: 3px;
-    font-size: 13px !important;
-    width: 30px;
-    line-height: 30px;
     text-align: center;
     background: -moz-linear-gradient(top, rgba(254,255,232,0) 0%, rgba(214,219,191,0.3) 100%) !important; /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(254,255,232,0)), color-stop(100%,rgba(214,219,191,0.3))) !important; /* Chrome,Safari4+ */
@@ -19,6 +16,14 @@ body.jsdisabled #block_accessibility_launchtoolbar {
     background: -ms-linear-gradient(top, rgba(254,255,232,0) 0%,rgba(214,219,191,0.3) 100%) !important; /* IE10+ */
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00feffe8', endColorstr='#4dd6dbbf',GradientType=0 ) !important; /* IE6-9 */
     background: linear-gradient(top, rgba(254,255,232,0) 0%,rgba(214,219,191,0.3) 100%) !important; /* W3C */
+
+    /*disable selection*/
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 #accessibility_controls .access-button:hover {
@@ -29,15 +34,6 @@ body.jsdisabled #block_accessibility_launchtoolbar {
     background: -ms-linear-gradient(top, rgba(254,255,232,0) 0%,rgba(214,219,191,0.5) 50%) !important; /* IE10+ */
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00feffe8', endColorstr='#80d6dbbf',GradientType=0 ) !important; /* IE6-9 */
     background: linear-gradient(top, rgba(254,255,232,0) 0%,rgba(214,219,191,0.5) 50%) !important; /* W3C */
-}
-
-
-#block_accessibility_inc {
-    font-size: 16px !important;
-}
-
-#block_accessibility_dec {
-    font-size: 10px !important;
 }
 
 .access-button a#block_accessibility_save {
@@ -54,9 +50,9 @@ body.jsdisabled #block_accessibility_launchtoolbar {
     background-position: center !important;
 }
 
-#accessibility_controls .access-button.disabled {
-    border: 1px solid #eee;
-    color: #ccc;
+#accessibility_controls .access-button .disabled {
+    opacity:0.3;
+    cursor:not-allowed;;
 }
 
 #accessibility_controls .access-button a {
@@ -64,6 +60,8 @@ body.jsdisabled #block_accessibility_launchtoolbar {
     cursor: pointer;
     color: #000;
     border-radius: 2px;
+    padding: .15em .3em;
+    min-width: 1.5em;
 }
 
 #accessibility_controls .access-button a:hover {
@@ -164,4 +162,8 @@ body.jsdisabled #block_accessibility_launchtoolbar {
 #toolbar-launch img {
 	padding: 0;
 	opacity: 0.6;
+}
+
+.atbar-always{
+    display: inline-block;
 }

--- a/userstyles.php
+++ b/userstyles.php
@@ -84,6 +84,9 @@ if (!empty($fontsize)) {
 
 // COLOUR SCHEMES CSS DECLARATIONS
 // ================================================
+/*
+	So far, selector * is used. This might cause some problems. Idea: Maybe better solution is to apply backgrounds to specific elements like body, .header, ...
+*/
 if (!empty($colourscheme)) {
 	// $colourscheme == 1 is reset, so don't output any styles
 	if($colourscheme > 1 && $colourscheme < 5){ // this is how many declarations we defined in edit_form.php


### PR DESCRIPTION
- block buttons accommodates accessibility settings now (e.g. for bigger size, bigger accessibility buttons)
- selection disabled on .access buttons (as buttons was selectable, this was a problem to usability)
- launchATbar bottun positioned
- (always) checkbox positioned correctly now (sometimes checkbox would stay in top line while label would move to next row)
- block's message box positioned
- disabled button styles changed (background, hover, cursor, etc...)

![rediesign1](https://cloud.githubusercontent.com/assets/6906827/3005592/8121f556-dde9-11e3-98a7-678d4093d965.PNG)
![rediesign2](https://cloud.githubusercontent.com/assets/6906827/3005593/8125949a-dde9-11e3-84ef-08f779be504d.PNG)
![rediesign3](https://cloud.githubusercontent.com/assets/6906827/3005594/81294414-dde9-11e3-8053-5bbbe9c2ff03.PNG)
![rediesign4](https://cloud.githubusercontent.com/assets/6906827/3005595/812e9612-dde9-11e3-85c3-763e7a28e07d.PNG)
![rediesign5](https://cloud.githubusercontent.com/assets/6906827/3005596/8131e240-dde9-11e3-9080-6324d603a9ba.PNG)
