### PR TITLE
More smooth actions in javascript

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Provides options for changing text size and colour scheme. Settings can be saved
 
 Also integrates ATbar from Southampton University ECS http://www.atbar.org. Code used under BSD Licence.
 
-To install, place all files in /blocks/accessibility and visit /admin/index.php in your browser. To achieve block appearance throughout entire Moodle site (so-called "Sticky block") once the plugin is installed into Moodle, it's recommended to add its instance onto the Moodle homepage. Homepage instance of the block enables “Page contexts” option in block instance configuration (F7) to be set to "Display throughout entire site".
+To install, place all files in /blocks/accessibility and visit /admin/index.php in your browser. To achieve block appearance throughout entire Moodle site (so-called "Sticky block") once the plugin is installed into Moodle, it's recommended to add its instance onto the Moodle homepage. Homepage instance of the block enables "Page contexts" option in block instance configuration (F7) to be set to "Display throughout entire site".
 
 This block was initially written by Mark Johnson <mark@barrenfrozenwasteland.com>
 It is copyright of Mark Johnson, Richard Taunton's Sixth Form College and contributors.

--- a/module.js
+++ b/module.js
@@ -400,12 +400,27 @@ M.block_accessibility = {
 	 */
 	reload_stylesheet: function(){
 		var cache_prevention_salt = new Date().getTime();
-		M.block_accessibility.sheetnode.set(
+
+		/*
+			Why wouldn't we just set the href attribute insted of creating a new node? Because before the new stylesheet is loaded and while old one is deleted, the page loose all the styles and all the elements get unstyled for a some time
+		*/
+		var oldStylesheet = M.block_accessibility.sheetnode;
+		var newStylesheet = oldStylesheet.cloneNode(true);
+		newStylesheet.set(
 			'href', M.cfg.wwwroot+
 			'/blocks/accessibility/userstyles.php?instance_id='+
 			M.block_accessibility.instance_id+
 			'&v='+cache_prevention_salt
 		); 
+		this.Y.one('head').append(newStylesheet);
+		newStylesheet.getDOMNode().onload = function(){ oldStylesheet.remove() };
+		M.block_accessibility.sheetnode = newStylesheet;
+
+
+		//alert(M.block_accessibility.sheetnode + ' '+ clone);
+
+		
+
 	},
 
 	/**


### PR DESCRIPTION
So far, for each action (change colour or font size) javascript would load userstyles.php stylesheet and set it as an argument to associated <link> element. This would cause all the styles to be lost before new stylesheet is loaded.

From now on, the old <link> element is preserved untill new stylesheet is fully loaded
