### PR TITLE
addinstance and myaddinstance lang strings added to all language files

### DIFF
--- a/lang/de/block_accessibility.php
+++ b/lang/de/block_accessibility.php
@@ -61,3 +61,6 @@ $string['config_fg_help'] = 'Define colour scheme foreground colour here. Keep i
 $string['config_bg'] = 'Background colour';
 $string['config_bg_help'] = 'Define colour scheme background colour here. Keep in mind that the background colour will be applied uniformly to all user interface elements.';
 $string['color_input_error'] = 'Please enter a color in a format as such: #FF0050';
+
+$string['accessibility:addinstance'] = 'Add a new Accessibility block';
+$string['accessibility:myaddinstance'] = 'Add a new Accessibility block to My home';

--- a/lang/es/block_accessibility.php
+++ b/lang/es/block_accessibility.php
@@ -61,3 +61,6 @@ $string['config_fg_help'] = 'Define colour scheme foreground colour here. Keep i
 $string['config_bg'] = 'Background colour';
 $string['config_bg_help'] = 'Define colour scheme background colour here. Keep in mind that the background colour will be applied uniformly to all user interface elements.';
 $string['color_input_error'] = 'Please enter a color in a format as such: #FF0050';
+
+$string['accessibility:addinstance'] = 'Add a new Accessibility block';
+$string['accessibility:myaddinstance'] = 'Add a new Accessibility block to My home';

--- a/lang/fr/block_accessibility.php
+++ b/lang/fr/block_accessibility.php
@@ -62,3 +62,6 @@ $string['config_fg_help'] = 'Define colour scheme foreground colour here. Keep i
 $string['config_bg'] = 'Background colour';
 $string['config_bg_help'] = 'Define colour scheme background colour here. Keep in mind that the background colour will be applied uniformly to all user interface elements.';
 $string['color_input_error'] = 'Please enter a color in a format as such: #FF0050';
+
+$string['accessibility:addinstance'] = 'Add a new Accessibility block';
+$string['accessibility:myaddinstance'] = 'Add a new Accessibility block to My home';

--- a/lang/hr/block_accessibility.php
+++ b/lang/hr/block_accessibility.php
@@ -64,3 +64,6 @@ $string['config_fg_help'] = 'Define colour scheme foreground colour here. Keep i
 $string['config_bg'] = 'Background colour';
 $string['config_bg_help'] = 'Define colour scheme background colour here. Keep in mind that the background colour will be applied uniformly to all user interface elements.';
 $string['color_input_error'] = 'Please enter a color in a format as such: #FF0050';
+
+$string['accessibility:addinstance'] = 'Dodaj novi Accessibility block';
+$string['accessibility:myaddinstance'] = 'Dodaj novi Accessibility block na glavnu stranicu';

--- a/lang/pt-br/block_accessibility.php
+++ b/lang/pt-br/block_accessibility.php
@@ -62,3 +62,6 @@ $string['config_fg_help'] = 'Define colour scheme foreground colour here. Keep i
 $string['config_bg'] = 'Background colour';
 $string['config_bg_help'] = 'Define colour scheme background colour here. Keep in mind that the background colour will be applied uniformly to all user interface elements.';
 $string['color_input_error'] = 'Please enter a color in a format as such: #FF0050';
+
+$string['accessibility:addinstance'] = 'Add a new Accessibility block';
+$string['accessibility:myaddinstance'] = 'Add a new Accessibility block to My home';


### PR DESCRIPTION
According to https://docs.moodle.org/dev/Blocks and related to #67 for english language, 

$string['accessibility:addinstance'] = 'Add a new Accessibility block';
$string['accessibility:myaddinstance'] = 'Add a new Accessibility block to My home'; 

were added to all the language. Translations are needed.
