### PR TITLE
IE < 11 adjustments

### DIFF
--- a/userstyles.php
+++ b/userstyles.php
@@ -32,7 +32,7 @@
 
 header('Content-Type: text/css', true);
 header("X-Content-Type-Options: nosniff"); // for IE
-//header('Cache-Control: no-cache');
+header('Cache-Control: no-cache');
 
 
 require_once('../../config.php');
@@ -90,7 +90,7 @@ if (!empty($fontsize)) {
 if (!empty($colourscheme)) {
 	// $colourscheme == 1 is reset, so don't output any styles
 	if($colourscheme > 1 && $colourscheme < 5){ // this is how many declarations we defined in edit_form.php
-		if(!empty($block_instance->config)){
+		if($block_instance->config !== NULL){
 			$fg_colour = $block_instance->config->{'fg'.$colourscheme};
 			$bg_colour = $block_instance->config->{'bg'.$colourscheme};
 		}
@@ -142,7 +142,8 @@ if (!empty($colourscheme)) {
 // ================================================
 for($i=2; $i<5; $i++) {  // this is how many declarations we defined in defaults.php
 	$colourscheme = $i;
-	if(!empty($block_instance->config)){
+	if($block_instance->config !== NULL){
+		//var_dump($block_instance->config->{'fg'.$colourscheme}, $block_instance->config->{'bg'.$colourscheme});
 		$fg_colour = $block_instance->config->{'fg'.$colourscheme};
 		$bg_colour = $block_instance->config->{'bg'.$colourscheme};
 	}

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2014072501;
+$plugin->version = 2014072502;
 $plugin->cron = 3600;
 $plugin->requires = 2011120500;
 $plugin->component = 'block_accessibility';


### PR DESCRIPTION
Possibly solves problems with IE's < 11 (at least for IE9 which were tested)

The problem was:
http://stackoverflow.com/questions/1184950/dynamically-loading-css-stylesheet-doesnt-work-on-ie

Tried to solve using proposed solution. The goal was to use createStyleSheet() to achieve the same effect as in non-IE browsers but this wasn't possible to implemented in past 4 days. It's decided to apply stylesheets directly modifying href attribute of original <link> element for IE<11 browsers. This removes smooth user experience for IE users but at least it works well. It's a good compromise. If anyone has better idea, please comment.

Tested in IE9! Works flawlessly 
