### PR TITLE
headings font-size scaling fixed

### DIFF
--- a/block_accessibility.php
+++ b/block_accessibility.php
@@ -146,22 +146,25 @@ class block_accessibility extends block_base {
 
 		// if any of increase/decrease buttons reached maximum size, disable it
 		if (isset($USER->fontsize)) {
-			if (accessibility_getsize($USER->fontsize) == MIN_PX_FONTSIZE) {
+			if (accessibility_getsize($USER->fontsize) == MIN_FONTSIZE) {
 				$dec_attrs['class'] = 'disabled';
 				unset($dec_attrs['href']);
 			}
-			if (accessibility_getsize($USER->fontsize) == MAX_PX_FONTSIZE) {
+			if (accessibility_getsize($USER->fontsize) == MAX_FONTSIZE) {
 				$inc_attrs['class'] = 'disabled';
 				unset($inc_attrs['href']);
 			}
 		}
 
 		// if user is not logged in, disable save button
+		// UPDATE 18.9.2014. Anyway the block will not be displayed for nonauthenticated users
+		/*
 		if (isset($USER->username) && (isset($USER->fontsize) || isset($USER->colourscheme))) {
 			$save_attrs['href'] = $db_url->out(false);
 		} else {
 			$save_attrs['class'] = 'disabled';
 		}
+		*/
 
 		// initialization of reset button
 		$reset_attrs = array(

--- a/changesize.php
+++ b/changesize.php
@@ -44,8 +44,11 @@ if (!isset($USER->defaultfontsize)) {
     $USER->defaultfontsize = DEFAULT_FONTSIZE;
 
     // if javascript enabled, get current font-size value directly from the page
+    // UPDATE 24.09.2014. It turns out not to be correct, needs to be adjusted...at least for clean theme...
+    /*
     $cur = optional_param('cur', 0, PARAM_INT);
     if ($cur) $USER->defaultfontsize = $cur;
+    */
 }
 
 // GET THE CURRENT FONT-SIZE VALUE IN PX
@@ -64,7 +67,8 @@ if ($current >= MIN_FONTSIZE && $current <= MAX_FONTSIZE) {
     // If we're already dealing with a percentage,
     $current = accessibility_getsize($current); // Get the size in pixels
 }
-// ok, we have font size in px
+
+// ok, we have font size in px now
 // ...
 
 // CALCULATE THE NEW FONT SIZE
@@ -106,6 +110,9 @@ switch($op) {
 
         $redirecturl = new moodle_url('/blocks/accessibility/database.php', $urlparams);
         redirect($redirecturl);
+
+
+        // ... REDIRECTED! EXIT
         
         break;
     default: // ERROR   
@@ -119,6 +126,7 @@ switch($op) {
 $USER->fontsize = $new; // If we've just increased or decreased, save the new size to the session
 
 if (accessibility_is_ajax()) {
+    // no redirect
     // it would be good idea to include userstyles.php here as HTTP response
     // this would save one extra HTTP request from module.js
 } else {

--- a/userstyles.php
+++ b/userstyles.php
@@ -70,14 +70,25 @@ else if (!empty($options->colourscheme)) $colourscheme = $options->colourscheme;
 // Echo out CSS for the body element. Use !important to override any other external stylesheets.
 if (!empty($fontsize)) {
 	echo '
+	
 	#page { /* block elements */
 		font-size: '.$fontsize.'% !important;
 		line-height:1.5; /*WCAG 2.0*/
 	}
+
 	#page *{
-		font-size: inherit !important;
 		line-height: inherit !important;
+		font-size: inherit !important;
 	}
+
+
+	/* issue #74 - default h* sizes from Moodle CSS */
+	#page #page-header h1, #page #region-main h1{font-size:'. (0.32 * $fontsize) .'px !important}
+	#page #page-header h2, #page #region-main h2{font-size:'. (0.28 * $fontsize) .'px !important}
+	#page #page-header h3, #page #region-main h3{font-size:'. (0.24 * $fontsize) .'px !important}
+	#page #page-header h4, #page #region-main h4{font-size:'. (0.20 * $fontsize) .'px !important}
+	#page #page-header h5, #page #region-main h5{font-size:'. (0.16 * $fontsize) .'px !important}
+	#page #page-header h6, #page #region-main h6{font-size:'. (0.12 * $fontsize) .'px !important}
 	';
 }
 


### PR DESCRIPTION
BUG: while entire page texts scale proportionally, headings gets smaller to the same size as normal text. This was fixed by modifying default Moodle's:

h1{font-size:32px}h2{font-size:28px}h3{font-size:24px}h4{font-size:20px}h5{font-size:16px}h6{font-size:12px}

to dynamically calculated values like:
# page #page-header h1, #page #region-main h1{font-size:'. (0.32 \* $fontsize) .'px !important}
# page #page-header h2, #page #region-main h2{font-size:'. (0.28 \* $fontsize) .'px !important}
# page #page-header h3, #page #region-main h3{font-size:'. (0.24 \* $fontsize) .'px !important}
# page #page-header h4, #page #region-main h4{font-size:'. (0.20 \* $fontsize) .'px !important}
# page #page-header h5, #page #region-main h5{font-size:'. (0.16 \* $fontsize) .'px !important}
# page #page-header h6, #page #region-main h6{font-size:'. (0.12 \* $fontsize) .'px !important}

Selectors are restricted to #page-header and #region-main as it's intended to avoid block's headings to enlarge as content's headings.

Initial idea was to use percentage table but this doesn't work
http://www.metahead.com/converting-font-sizes-from-pixel-point-em-percent
http://stackoverflow.com/questions/3055469/html-what-are-the-percentages-of-the-heading-tags

Also, initial default font-size was so far passed to php script via JS but it appear it is not correct so it's temporarly disabled in changesize.php; Default is set to 13px / 100%
