### PR TITLE
disabling/enabling buttons fixed

### DIFF
--- a/block_accessibility.php
+++ b/block_accessibility.php
@@ -144,16 +144,28 @@ class block_accessibility extends block_base {
 			'id' => "block_accessibility_save"
 		);
 
+		// initialization of reset button
+		$reset_attrs = array(
+			'id' => 'block_accessibility_reset',
+			'title' => get_string('resettext', 'block_accessibility'),
+			'href' => $size_url->out(false, array('op' => 'reset'))
+		);
+
+
 		// if any of increase/decrease buttons reached maximum size, disable it
 		if (isset($USER->fontsize)) {
-			if (accessibility_getsize($USER->fontsize) == MIN_FONTSIZE) {
+			if ($USER->fontsize == MIN_FONTSIZE) {
 				$dec_attrs['class'] = 'disabled';
 				unset($dec_attrs['href']);
 			}
-			if (accessibility_getsize($USER->fontsize) == MAX_FONTSIZE) {
+			if ($USER->fontsize == MAX_FONTSIZE) {
 				$inc_attrs['class'] = 'disabled';
 				unset($inc_attrs['href']);
 			}
+		}
+		// or disable reset button
+		else{
+			$reset_attrs['class'] = 'disabled';
 		}
 
 		// if user is not logged in, disable save button
@@ -166,12 +178,6 @@ class block_accessibility extends block_base {
 		}
 		*/
 
-		// initialization of reset button
-		$reset_attrs = array(
-			'id' => 'block_accessibility_reset',
-			'title' => get_string('resettext', 'block_accessibility'),
-			'href' => $size_url->out(false, array('op' => 'reset'))
-		);
 
 		// initialization of scheme profiles buttons
 		$c1_attrs = array(
@@ -190,12 +196,16 @@ class block_accessibility extends block_base {
 			'id' => 'block_accessibility_colour4',
 			'href' => $colour_url->out(false, array('scheme' => 4))
 		);
+		if (!isset($USER->colourscheme)) {
+			$c1_attrs['class'] = 'disabled';
+		}
 
 		// RENDER BLOCK HTML
 		// ===============================================
 		$content = '';
 
 		$strchar = get_string('char', 'block_accessibility');
+		$resetchar = "R";
 		$divattrs = array('id' => 'accessibility_controls', 'class' => 'content');
 		$listattrs = array('id' => 'block_accessibility_textresize', 'class' => 'button_row');
 
@@ -224,19 +234,19 @@ class block_accessibility extends block_base {
 		$content .= html_writer::start_tag('ul', array('id' => 'block_accessibility_changecolour'));
 
 		$content .= html_writer::start_tag('li', array('class' => 'access-button'));
-		$content .= html_writer::tag('a', get_string('char', 'block_accessibility'), $c1_attrs);
+		$content .= html_writer::tag('a', $resetchar, $c1_attrs);
 		$content .= html_writer::end_tag('li');
 
 		$content .= html_writer::start_tag('li', array('class' => 'access-button'));
-		$content .= html_writer::tag('a', get_string('char', 'block_accessibility'), $c2_attrs);
+		$content .= html_writer::tag('a', $strchar, $c2_attrs);
 		$content .= html_writer::end_tag('li');
 
 		$content .= html_writer::start_tag('li', array('class' => 'access-button'));
-		$content .= html_writer::tag('a', get_string('char', 'block_accessibility'), $c3_attrs);
+		$content .= html_writer::tag('a', $strchar, $c3_attrs);
 		$content .= html_writer::end_tag('li');
 
 		$content .= html_writer::start_tag('li', array('class' => 'access-button'));
-		$content .= html_writer::tag('a', get_string('char', 'block_accessibility'), $c4_attrs);
+		$content .= html_writer::tag('a', $strchar, $c4_attrs);
 		$content .= html_writer::end_tag('li');
 
 		$content .= html_writer::end_tag('ul');

--- a/changesize.php
+++ b/changesize.php
@@ -62,13 +62,13 @@ else if ($userstyle = $DB->get_record('block_accessibility', array('userid' => $
     $current = $userstyle->fontsize; // user stored settings
 }
 
-// if value is in %, convert it to px
-if ($current >= MIN_FONTSIZE && $current <= MAX_FONTSIZE) {
+// if value is in %, convert it to px to get array index of px so we are able to increment it...
+if ($current > MAX_PX_FONTSIZE) { // must be in % then
     // If we're already dealing with a percentage,
     $current = accessibility_getsize($current); // Get the size in pixels
 }
 
-// ok, we have font size in px now
+// ok, we have font size in px now, get new percentage value from it
 // ...
 
 // CALCULATE THE NEW FONT SIZE
@@ -121,7 +121,7 @@ switch($op) {
         exit();
 }
 
-// SET THE NEW FONT SIZE
+// SET THE NEW FONT SIZE IN % !!
 // =========================================================
 $USER->fontsize = $new; // If we've just increased or decreased, save the new size to the session
 

--- a/lib.php
+++ b/lib.php
@@ -56,6 +56,7 @@ function accessibility_getsize($size) {
 
     // Define the array of sizes in px against sizes as %
     // make sure to maintain defined constants above in the script
+    // http://yuilibrary.com/yui/docs/cssfonts/
     $sizes = array(
         10 => 77,
         11 => 85,

--- a/module.js
+++ b/module.js
@@ -15,7 +15,9 @@ M.block_accessibility = {
 	// only in JS-mode, because .getStyle('fontSize') will return computed style in px
 	DAFAULT_PX_FONTSIZE: 13,
 	MAX_PX_FONTSIZE: 26,
-	MIN_PX_FONTSIZE: 10,
+	MIN_PX_FONTSIZE: 10+1, // +1 because of unknown error...YUI for 77% returns style of 11px
+
+	MAIN_SELECTOR : '#page', // userstyles.php applies CSS font-size to this element
 
 	//stylesheet: '',
 
@@ -42,7 +44,8 @@ M.block_accessibility = {
 
 		// Set default font size
 		//this.log('Initial size: '+Y.one('body').getStyle('fontSize'));
-		this.defaultsize = M.block_accessibility.get_current_fontsize('body');
+		//this.defaultsize = M.block_accessibility.get_current_fontsize('body'); // this is disabled because it gives false results...
+		this.defaultsize = M.block_accessibility.DEFAULT_FONTSIZE; 
 
 		// Attach the click handler
 		Y.all('#block_accessibility_textresize a').on('click', function(e) {
@@ -207,7 +210,7 @@ M.block_accessibility = {
 
 							// now that we updated user setting to the server, load updated stylesheet
 							M.block_accessibility.reload_stylesheet();  
-							var new_fontsize =  M.block_accessibility.get_current_fontsize('#page');
+							var new_fontsize =  M.block_accessibility.get_current_fontsize(M.block_accessibility.MAIN_SELECTOR);
 							M.block_accessibility.log('Increasing size to '+new_fontsize);
 
 							// Disable/enable buttons as necessary
@@ -220,9 +223,8 @@ M.block_accessibility = {
 							}
 							if (new_fontsize >= max_fontsize) {
 								M.block_accessibility.toggle_textsizer('inc', 'off');
-							} else if (new_fontsize <= min_fontsize) {
-								M.block_accessibility.toggle_textsizer('dec', 'on');
 							}
+							M.block_accessibility.toggle_textsizer('dec', 'on');
 							M.block_accessibility.toggle_textsizer('save', 'on');
 							
 						},
@@ -243,10 +245,9 @@ M.block_accessibility = {
 
 							// now that we updated user setting to the server, load updated stylesheet
 							M.block_accessibility.reload_stylesheet();
-							var new_fontsize =  M.block_accessibility.get_current_fontsize('#page');
+							var new_fontsize =  M.block_accessibility.get_current_fontsize(M.block_accessibility.MAIN_SELECTOR);
 							M.block_accessibility.log('Decreasing size to '+new_fontsize);
 
-							
 							// Disable/enable buttons as necessary
 							var min_fontsize = M.block_accessibility.MIN_PX_FONTSIZE;
 							var max_fontsize = M.block_accessibility.MAX_PX_FONTSIZE;
@@ -257,9 +258,8 @@ M.block_accessibility = {
 							}
 							if (new_fontsize <= min_fontsize) {
 								M.block_accessibility.toggle_textsizer('dec', 'off');
-							} else if (new_fontsize == max_fontsize) {
-								M.block_accessibility.toggle_textsizer('inc', 'on');
-							}
+							} 
+							M.block_accessibility.toggle_textsizer('inc', 'on');
 							M.block_accessibility.toggle_textsizer('save', 'on');
 							
 						},
@@ -280,7 +280,7 @@ M.block_accessibility = {
 
 							// now that we updated user setting to the server, load updated stylesheet
 							M.block_accessibility.reload_stylesheet();
-							var new_fontsize =  M.block_accessibility.get_current_fontsize('#page');
+							var new_fontsize =  M.block_accessibility.get_current_fontsize(M.block_accessibility.MAIN_SELECTOR);
 							M.block_accessibility.log('Resetting size to '+new_fontsize);
   
 							// Disable/enable buttons as necessary
@@ -334,8 +334,14 @@ M.block_accessibility = {
 			on: {
 				success: function (id, o) {
 					M.block_accessibility.reload_stylesheet(); 
-					if(scheme == 1) M.block_accessibility.toggle_textsizer('save', 'off'); // reset
-					else M.block_accessibility.toggle_textsizer('save', 'on');
+					if(scheme == 1){
+						M.block_accessibility.toggle_textsizer('save', 'off'); // reset
+						M.block_accessibility.toggle_textsizer('colour1', 'off');
+					}
+					else{
+						M.block_accessibility.toggle_textsizer('save', 'on');
+						M.block_accessibility.toggle_textsizer('colour1', 'on');
+					} 
 				},
 				failure: function(id, o) {
 					alert(get_string('jsnocolour', 'block_accessibility')+': '+o.status+' '+o.statusText);
@@ -456,6 +462,7 @@ M.block_accessibility = {
 	},
 
 	/**
+	 * Stripes px or % and gives value only
 	 * For improved user experience, only in JS-mode, we can set current font size as default font size
 	 * We would initially put 100%, but it doesn't have to be true for all themes
 	 * Also font-size value can be in % or in px, there is mapping defined in lib.php in the block

--- a/version.php
+++ b/version.php
@@ -31,7 +31,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2014072502;
+$plugin->version = 2014092401;
 $plugin->cron = 3600;
 $plugin->requires = 2011120500;
 $plugin->component = 'block_accessibility';


### PR DESCRIPTION
Disabling/enabling buttons within block wasn't working correctly. For example: Only one level of A+ is available; Text reset button gets enabled after A+ is used twice; Reset buttons are often disabled for no reason etc...

Also Colours reset button is now disabled/enabled as well and it's renamed from 'A' to 'R'
