### PR TITLE
Fixed content-ype for moodle 2.8

### DIFF
--- a/userstyles.php
+++ b/userstyles.php
@@ -29,7 +29,10 @@
  * @author Mark Johnson <mark.johnson@tauntons.ac.uk>                  (6)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later (7)
  */
- 
+
+/**
+ config.php overwrites header content-type in moodle 2.8
+ */
 require_once('../../config.php');
 
 header('Content-Type: text/css', true);

--- a/userstyles.php
+++ b/userstyles.php
@@ -29,13 +29,12 @@
  * @author Mark Johnson <mark.johnson@tauntons.ac.uk>                  (6)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later (7)
  */
+ 
+require_once('../../config.php');
 
 header('Content-Type: text/css', true);
 header("X-Content-Type-Options: nosniff"); // for IE
 header('Cache-Control: no-cache');
-
-
-require_once('../../config.php');
 
 if (!isloggedin()) die();
 


### PR DESCRIPTION
require_once('../../config.php'); should be executed before header, otherwise header content-type is overwritten for moodle 2.8 since moodle/lib/setup.php changed from 2.7