### PR TITLE
Small mod to AtBar pop-outs to stop them appearing over selected text.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -125,3 +125,28 @@ body.jsdisabled #block_accessibility_launchtoolbar {
     display:none;
 
 }
+
+/* Fix dictionary/text to speech/styles pop-up to allow scrolling and make responsive */
+#at-facebox{
+width: 100% !important;
+position: fixed !important;
+bottom: 0px !important;
+right: auto !important;
+left: 0px !important;
+top: auto !important;
+}
+.at-fb-tb-body{
+width: 96vw !important;
+}
+div.at-fb-content div{
+height: 30vh !important;
+} 
+.at-fb-footer{
+width: 40px !important;
+float: right !important;
+position: absolute !important;
+top: 10px !important;
+right: 0px !important;
+border-top: 0px solid transparent !important;
+}
+


### PR DESCRIPTION
Dictionary, text to speech and styles pop-up modals can appear over selected. I fixed the modal position to the bottom and made responsive. Works well on smartphones too.